### PR TITLE
Update Comic Sticks to version 1.7.0.

### DIFF
--- a/com.github.rkoesters.xkcd-gtk.yaml
+++ b/com.github.rkoesters.xkcd-gtk.yaml
@@ -3,7 +3,7 @@
 app-id: com.github.rkoesters.xkcd-gtk
 
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 
 sdk: org.freedesktop.Sdk
 sdk-extensions:
@@ -22,13 +22,18 @@ modules:
     buildsystem: simple
     build-commands:
       - 'ln -s "$(pwd)/vendor" src/'
-      - 'cd src; . /usr/lib/sdk/golang/enable.sh; make BUILDFLAGS=-mod=vendor'
-      - 'cd src; . /usr/lib/sdk/golang/enable.sh; make install prefix=/app'
+      - 'cd src && . /usr/lib/sdk/golang/enable.sh && make'
+      - 'cd src && . /usr/lib/sdk/golang/enable.sh && make install prefix=/app'
 
     sources:
+      - type: file
+        path: modules.txt
+        dest: vendor
+        dest-filename: modules.txt
+
       - type: git
         url: https://github.com/rkoesters/xkcd-gtk.git
-        tag: 1.6.5
+        tag: v1.7.0
         dest: src
 
       - type: git
@@ -43,13 +48,18 @@ modules:
 
       - type: git
         url: https://github.com/blevesearch/bleve.git
-        tag: v2.3.2
+        tag: v2.3.6
         dest: vendor/github.com/blevesearch/bleve/v2
 
       - type: git
         url: https://github.com/blevesearch/bleve_index_api.git
-        tag: v1.0.1
+        tag: v1.0.5
         dest: vendor/github.com/blevesearch/bleve_index_api
+
+      - type: git
+        url: https://github.com/blevesearch/geo.git
+        tag: v0.1.16
+        dest: vendor/github.com/blevesearch/geo
 
       - type: git
         url: https://github.com/blevesearch/go-porterstemmer.git
@@ -63,12 +73,12 @@ modules:
 
       - type: git
         url: https://github.com/blevesearch/mmap-go.git
-        tag: v1.0.3
+        tag: v1.0.4
         dest: vendor/github.com/blevesearch/mmap-go
 
       - type: git
         url: https://github.com/blevesearch/scorch_segment_api.git
-        tag: v2.1.0
+        tag: v2.1.4
         dest: vendor/github.com/blevesearch/scorch_segment_api/v2
 
       - type: git
@@ -88,38 +98,44 @@ modules:
 
       - type: git
         url: https://github.com/blevesearch/vellum.git
-        tag: v1.0.7
+        tag: v1.0.9
         dest: vendor/github.com/blevesearch/vellum
 
       - type: git
         url: https://github.com/blevesearch/zapx.git
-        tag: v11.3.3
+        tag: v11.3.7
         dest: vendor/github.com/blevesearch/zapx/v11
 
       - type: git
         url: https://github.com/blevesearch/zapx.git
-        tag: v12.3.3
+        tag: v12.3.7
         dest: vendor/github.com/blevesearch/zapx/v12
 
       - type: git
         url: https://github.com/blevesearch/zapx.git
-        tag: v13.3.3
+        tag: v13.3.7
         dest: vendor/github.com/blevesearch/zapx/v13
 
       - type: git
         url: https://github.com/blevesearch/zapx.git
-        tag: v14.3.3
+        tag: v14.3.7
         dest: vendor/github.com/blevesearch/zapx/v14
 
       - type: git
         url: https://github.com/blevesearch/zapx.git
-        tag: v15.3.3
+        tag: v15.3.8
         dest: vendor/github.com/blevesearch/zapx/v15
 
       - type: git
         url: https://github.com/emirpasic/gods.git
         tag: v1.18.1
         dest: vendor/github.com/emirpasic/gods
+
+      - type: git
+        url: https://github.com/golang/geo.git
+        # v0.0.0-20210211234256-740aa86cb551
+        commit: 740aa86cb551
+        dest: vendor/github.com/golang/geo
 
       - type: git
         url: https://github.com/golang/protobuf.git
@@ -137,6 +153,12 @@ modules:
         dest: vendor/github.com/gotk3/gotk3
 
       - type: git
+        url: https://github.com/json-iterator/go.git
+        # v0.0.0-20171115153421-f7279a603ede
+        commit: f7279a603ede
+        dest: vendor/github.com/json-iterator/go
+
+      - type: git
         url: https://github.com/rkoesters/xdg.git
         tag: v0.0.1
         dest: vendor/github.com/rkoesters/xdg
@@ -148,11 +170,10 @@ modules:
 
       - type: git
         url: https://github.com/etcd-io/bbolt.git
-        tag: v1.3.6
+        tag: v1.3.7
         dest: vendor/go.etcd.io/bbolt
 
       - type: git
         url: https://go.googlesource.com/sys.git
-        # v0.0.0-20200923182605-d9f96fdee20d
-        commit: d9f96fdee20d
+        tag: v0.4.0
         dest: vendor/golang.org/x/sys

--- a/modules.txt
+++ b/modules.txt
@@ -1,0 +1,144 @@
+# github.com/RoaringBitmap/roaring v0.9.4
+## explicit; go 1.14
+github.com/RoaringBitmap/roaring
+github.com/RoaringBitmap/roaring/internal
+# github.com/bits-and-blooms/bitset v1.2.0
+## explicit; go 1.14
+github.com/bits-and-blooms/bitset
+# github.com/blevesearch/bleve/v2 v2.3.6
+## explicit; go 1.18
+github.com/blevesearch/bleve/v2
+github.com/blevesearch/bleve/v2/analysis
+github.com/blevesearch/bleve/v2/analysis/analyzer/keyword
+github.com/blevesearch/bleve/v2/analysis/analyzer/standard
+github.com/blevesearch/bleve/v2/analysis/datetime/flexible
+github.com/blevesearch/bleve/v2/analysis/datetime/optional
+github.com/blevesearch/bleve/v2/analysis/lang/en
+github.com/blevesearch/bleve/v2/analysis/token/lowercase
+github.com/blevesearch/bleve/v2/analysis/token/porter
+github.com/blevesearch/bleve/v2/analysis/token/stop
+github.com/blevesearch/bleve/v2/analysis/tokenizer/single
+github.com/blevesearch/bleve/v2/analysis/tokenizer/unicode
+github.com/blevesearch/bleve/v2/document
+github.com/blevesearch/bleve/v2/geo
+github.com/blevesearch/bleve/v2/index/scorch
+github.com/blevesearch/bleve/v2/index/scorch/mergeplan
+github.com/blevesearch/bleve/v2/index/upsidedown
+github.com/blevesearch/bleve/v2/index/upsidedown/store/boltdb
+github.com/blevesearch/bleve/v2/index/upsidedown/store/gtreap
+github.com/blevesearch/bleve/v2/mapping
+github.com/blevesearch/bleve/v2/numeric
+github.com/blevesearch/bleve/v2/registry
+github.com/blevesearch/bleve/v2/search
+github.com/blevesearch/bleve/v2/search/collector
+github.com/blevesearch/bleve/v2/search/facet
+github.com/blevesearch/bleve/v2/search/highlight
+github.com/blevesearch/bleve/v2/search/highlight/format/html
+github.com/blevesearch/bleve/v2/search/highlight/fragmenter/simple
+github.com/blevesearch/bleve/v2/search/highlight/highlighter/html
+github.com/blevesearch/bleve/v2/search/highlight/highlighter/simple
+github.com/blevesearch/bleve/v2/search/query
+github.com/blevesearch/bleve/v2/search/scorer
+github.com/blevesearch/bleve/v2/search/searcher
+github.com/blevesearch/bleve/v2/size
+# github.com/blevesearch/bleve_index_api v1.0.5
+## explicit; go 1.18
+github.com/blevesearch/bleve_index_api
+# github.com/blevesearch/geo v0.1.16
+## explicit; go 1.12
+github.com/blevesearch/geo/geojson
+github.com/blevesearch/geo/s2
+# github.com/blevesearch/go-porterstemmer v1.0.3
+## explicit; go 1.13
+github.com/blevesearch/go-porterstemmer
+# github.com/blevesearch/gtreap v0.1.1
+## explicit; go 1.13
+github.com/blevesearch/gtreap
+# github.com/blevesearch/mmap-go v1.0.4
+## explicit; go 1.13
+github.com/blevesearch/mmap-go
+# github.com/blevesearch/scorch_segment_api/v2 v2.1.4
+## explicit; go 1.18
+github.com/blevesearch/scorch_segment_api/v2
+# github.com/blevesearch/segment v0.9.0
+## explicit; go 1.13
+github.com/blevesearch/segment
+# github.com/blevesearch/snowballstem v0.9.0
+## explicit; go 1.13
+github.com/blevesearch/snowballstem
+github.com/blevesearch/snowballstem/english
+# github.com/blevesearch/upsidedown_store_api v1.0.1
+## explicit; go 1.13
+github.com/blevesearch/upsidedown_store_api
+# github.com/blevesearch/vellum v1.0.9
+## explicit; go 1.18
+github.com/blevesearch/vellum
+github.com/blevesearch/vellum/levenshtein
+github.com/blevesearch/vellum/regexp
+github.com/blevesearch/vellum/utf8
+# github.com/blevesearch/zapx/v11 v11.3.7
+## explicit; go 1.18
+github.com/blevesearch/zapx/v11
+# github.com/blevesearch/zapx/v12 v12.3.7
+## explicit; go 1.18
+github.com/blevesearch/zapx/v12
+# github.com/blevesearch/zapx/v13 v13.3.7
+## explicit; go 1.18
+github.com/blevesearch/zapx/v13
+# github.com/blevesearch/zapx/v14 v14.3.7
+## explicit; go 1.18
+github.com/blevesearch/zapx/v14
+# github.com/blevesearch/zapx/v15 v15.3.8
+## explicit; go 1.18
+github.com/blevesearch/zapx/v15
+# github.com/emirpasic/gods v1.18.1
+## explicit; go 1.2
+github.com/emirpasic/gods/containers
+github.com/emirpasic/gods/sets
+github.com/emirpasic/gods/sets/treeset
+github.com/emirpasic/gods/trees
+github.com/emirpasic/gods/trees/redblacktree
+github.com/emirpasic/gods/utils
+# github.com/golang/geo v0.0.0-20210211234256-740aa86cb551
+## explicit; go 1.12
+github.com/golang/geo/r1
+github.com/golang/geo/r2
+github.com/golang/geo/r3
+github.com/golang/geo/s1
+# github.com/golang/protobuf v1.3.2
+## explicit
+github.com/golang/protobuf/proto
+# github.com/golang/snappy v0.0.1
+## explicit
+github.com/golang/snappy
+# github.com/gotk3/gotk3 v0.6.1
+## explicit; go 1.14
+github.com/gotk3/gotk3/cairo
+github.com/gotk3/gotk3/gdk
+github.com/gotk3/gotk3/glib
+github.com/gotk3/gotk3/gtk
+github.com/gotk3/gotk3/internal/callback
+github.com/gotk3/gotk3/internal/closure
+github.com/gotk3/gotk3/internal/slab
+github.com/gotk3/gotk3/pango
+# github.com/json-iterator/go v0.0.0-20171115153421-f7279a603ede
+## explicit
+github.com/json-iterator/go
+# github.com/mschoch/smat v0.2.0
+## explicit; go 1.13
+github.com/mschoch/smat
+# github.com/rkoesters/xdg v0.0.1
+## explicit; go 1.13
+github.com/rkoesters/xdg
+github.com/rkoesters/xdg/basedir
+# github.com/rkoesters/xkcd v1.4.0
+## explicit; go 1.13
+github.com/rkoesters/xkcd
+# go.etcd.io/bbolt v1.3.7
+## explicit; go 1.17
+go.etcd.io/bbolt
+# golang.org/x/sys v0.4.0
+## explicit; go 1.17
+golang.org/x/sys/internal/unsafeheader
+golang.org/x/sys/unix
+golang.org/x/sys/windows


### PR DESCRIPTION
Release notes: https://github.com/rkoesters/xkcd-gtk/releases/tag/v1.7.0