### PR TITLE
Bump Comic Sticks to v1.7.1.

### DIFF
--- a/com.github.rkoesters.xkcd-gtk.yaml
+++ b/com.github.rkoesters.xkcd-gtk.yaml
@@ -33,7 +33,7 @@ modules:
 
       - type: git
         url: https://github.com/rkoesters/xkcd-gtk.git
-        tag: v1.7.0
+        tag: v1.7.1
         dest: src
 
       - type: git


### PR DESCRIPTION
Release notes: https://github.com/rkoesters/xkcd-gtk/releases/tag/v1.7.1